### PR TITLE
Fix MCP schema component names

### DIFF
--- a/scripts/generate_webapi.rb
+++ b/scripts/generate_webapi.rb
@@ -106,7 +106,7 @@ def generate_openapi_component(path, output_dir)
   visitors = [
     InvalidKeysRemover.new,
     ReferenceFixer.new,
-    AcronymsFixer.new('DND' => 'Dnd'),
+    AcronymsFixer.new('DND' => 'Dnd', 'MCP' => 'Mcp'),
     TypeFixer.new,
     UserProfileRefFixer.new,
     TeamProfileRefFixer.new,

--- a/scripts/tests/visitors_test.rb
+++ b/scripts/tests/visitors_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/visitors'
+
+class VisitorsTest < Minitest::Test
+  def test_acronyms_fixer_normalizes_mcp_component_names_and_references
+    schema = JSON.parse(<<~JSON)
+      {
+        "$ref": "#/definitions/AdminAppsMCPServersListResponse",
+        "definitions": {
+          "AdminAppsMCPServersListResponse": { "type": "object" }
+        }
+      }
+    JSON
+
+    AcronymsFixer.new('MCP' => 'Mcp').walk(schema)
+
+    assert_equal '#/definitions/AdminAppsMcpServersListResponse', schema['$ref']
+    assert_equal({ 'type' => 'object' }, schema.dig('definitions', 'AdminAppsMcpServersListResponse'))
+    refute schema['definitions'].key?('AdminAppsMCPServersListResponse')
+  end
+end


### PR DESCRIPTION
## Summary
- normalize quicktype MCP component names to the response-model naming convention
- cover MCP component and reference normalization with a generator-script regression test

## Verification
- mise exec ruby@4.0.5 -- make test-scripts

## CI context
Fixes the scheduled Schema Update failure where admin.apps.mcp.servers.list referenced AdminAppsMcpServersListResponse, while quicktype emitted the component as AdminAppsMCPServersListResponse.