### PR TITLE
Fix schema group trait casing

### DIFF
--- a/scripts/process_webapi.rb
+++ b/scripts/process_webapi.rb
@@ -1458,7 +1458,7 @@ class SchemaGroupDeterminer
     if type_name.end_with?('Response')
       # Extract the prefix before "Response"
       prefix = type_name.gsub(/Response$/, '')
-      return GroupNameFormatter.capitalize_group_name(APIGroupResolver.group_for(prefix))
+      return APIGroupResolver.group_for(prefix)
     end
 
     # For non-response types, put in Common

--- a/scripts/test_process_webapi.rb
+++ b/scripts/test_process_webapi.rb
@@ -25,4 +25,29 @@ class ProcessWebAPITest < Minitest::Test
 
     assert_equal 'Unable to determine Slack API group for FutureFeatureCreate', error.message
   end
+
+  def test_schema_groups_are_canonical_before_trait_formatting
+    group = SchemaGroupDeterminer.determine_schema_group('OauthV2ExchangeResponse')
+
+    assert_equal 'oauth', group
+    assert_equal 'OAuth', GroupNameFormatter.capitalize_group_name(group)
+  end
+
+  def test_component_splitter_uses_the_oauth_trait
+    content = <<~SWIFT
+      /// Types generated from the components section of the OpenAPI document.
+      public enum Components {
+          public enum Schemas {
+              /// - Remark: Generated from `#/components/schemas/OauthV2ExchangeResponse`.
+              public struct OauthV2ExchangeResponse: Codable {
+              }
+          }
+      }
+    SWIFT
+
+    result = ComponentsSplitter.new('/tmp').send(:parse_components_by_schemas, content)
+
+    assert_equal ['oauth'], result[:groups].keys
+    assert_includes result[:groups]['oauth'], '#if WebAPI_OAuth'
+  end
 end


### PR DESCRIPTION
## Summary

- Preserve canonical lowercase group identifiers while splitting response schemas.
- Prevent OAuth and OpenID component schemas from being emitted behind inactive traits.
- Add regression coverage for the OAuth component trait.

## Validation

- `mise exec ruby@4.0.6 -- make test-scripts`

## Local toolchain note

Full `make generate` reached Swift OpenAPI generation, but the local macOS Swift dependency-manifest compiler stalled without source diagnostics. GitHub Actions will run the complete generation and Swift test suite on Linux.
