### PR TITLE
Prepare 2026.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The `PATCH` segment is a release counter within the month, not a SemVer compatib
 
 ## Unreleased
 
+## [2026.9.0] - 2026-09-03
+
+### Added
+
+* Added generated Web API operations for methods without response examples, including new Admin, Apps, Assistant, and Entity coverage - #121
+* Expanded generated Web API and shared model coverage from the latest Slack schemas - #127, #129
+* Added generated Agents and Blocks Web API groups and traits - #133
+
+### Changed
+
+* Made schema generation reproducible with a locked quicktype toolchain, fail-fast processing, bounded concurrency, generated-tree PR gating, and required script tests - #123
+* Updated the Ruby toolchain to `4.0.6` and quicktype to v26 - #122, #125, #126
+* Updated the GitHub Actions Node setup action to v7 - #124
+
+### Fixed
+
+* Fixed MCP response component naming during Web API schema generation - #128
+* Made Web API group discovery use vendored schema metadata and fail generation instead of emitting an unknown group - #131
+* Preserved canonical OAuth and OpenID group names so their generated components use active traits - #132
+
 ## [2026.7.0] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use the package directly:
 dependencies: [
     .package(
         url: "https://github.com/ainame/swift-slack.git",
-        from: "2026.7.0"
+        from: "2026.9.0"
     )
 ]
 ```
@@ -44,7 +44,7 @@ For smaller builds, enable only the traits your app needs:
 ```swift
     .package(
         url: "https://github.com/ainame/swift-slack.git",
-        from: "2026.7.0",
+        from: "2026.9.0",
         traits: [
             "SocketMode",   // WebSocket support
             "Events",       // Events API
@@ -151,7 +151,7 @@ The built-in Hummingbird integration is opt-in, so enable the `HummingbirdHTTPAd
 dependencies: [
     .package(
         url: "https://github.com/ainame/swift-slack.git",
-        from: "2026.7.0",
+        from: "2026.9.0",
         traits: [
             "Events",
             "HummingbirdHTTPAdapter",


### PR DESCRIPTION
## Summary

- add the dated `2026.9.0` changelog section from merged PRs since `2026.7.0`
- update README package dependency examples to `2026.9.0`

## Verification

- `git diff --check`
- Swift build and tests not run because this PR changes release metadata only

## Publication

After this PR merges, publish `2026.9.0` from a clean local `main` that exactly matches `origin/main`.
